### PR TITLE
Update package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "tape test/*.spec.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ArtZanko/gulp-tap-xunit.git"
-  },
+  "repository": "ArtZanko/gulp-tap-xunit",
   "keywords": [
     "tape",
     "gulp",


### PR DESCRIPTION
Don't know why, but right now on npm site I can't see link to repo
Just use shortcut. I hope it'll fix the issue
